### PR TITLE
Refactor visit logging to queued processing

### DIFF
--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -128,59 +128,42 @@ export async function logUserData(location) {
   const environment = process.env.NEXT_PUBLIC_ENV || 'unknown';
   const versionNumber = process.env.NEXT_PUBLIC_Version_Number || 'unknown';
 
-  let userId;
-
-  // Check if this IP already has a user_id assigned
-  const { data: existingUsers, error: fetchError } = await supabase
+  const { data: userMapping, error: mappingError } = await supabase
     .from('user_ip_mapping')
+    .upsert(
+      {
+        ip_address: ip,
+        user_id: uuidv4(),
+      },
+      {
+        onConflict: 'ip_address',
+      }
+    )
     .select('user_id')
-    .eq('ip_address', ip);
+    .single();
 
-  if (fetchError) {
-    console.error('Error fetching IP mapping:', fetchError);
+  if (mappingError || !userMapping) {
+    console.error('Error upserting IP mapping:', mappingError);
     return;
   }
 
-  if (existingUsers.length === 0) {
-    // If no user exists for this IP, create a new UUID
-    userId = uuidv4();
+  const visitRecord = {
+    short_path: location,
+    ip_address: ip,
+    user_agent: userAgent,
+    environment,
+    version_number: versionNumber,
+    user_id: userMapping.user_id,
+    browser: getBrowser(userAgent),
+    os: getOS(userAgent),
+    received_at: new Date().toISOString(),
+  };
 
-    // Insert the new mapping for this IP and user_id
-    const { error: insertError } = await supabase
-      .from('user_ip_mapping')
-      .insert([
-        {
-          ip_address: ip,
-          user_id: userId,
-        }
-      ]);
+  const { error: enqueueError } = await supabase.from('visit_queue').insert([visitRecord]);
 
-    if (insertError) {
-      console.error('Error inserting IP mapping:', insertError);
-      return;
-    }
+  if (enqueueError) {
+    console.error('Error enqueueing visit for async processing:', enqueueError);
   } else {
-    // Use the existing user_id from the IP mapping
-    userId = existingUsers[0].user_id;
-  }
-
-  // Inserting log data into Supabase
-  const { error } = await supabase.from('visits').insert([
-    {
-      short_path: location,
-      ip_address: ip,
-      user_agent: userAgent,
-      environment: environment,
-      version_number: versionNumber,
-      user_id: userId,
-      browser: getBrowser(userAgent),
-      os: getOS(userAgent)
-    }
-  ]);
-
-  if (error) {
-    console.error('Error logging user data to Supabase:', error);
-  } else {
-    console.log('User data logged successfully!');
+    console.log('Visit enqueued for async processing');
   }
 }

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,9 @@
+# Supabase operational notes
+
+## Visit queue processing
+- `src/app/utils.js` now enqueues visit payloads into the `visit_queue` table instead of inserting directly into `visits`.
+- A scheduled cron or Supabase Edge Function should batch-consume `visit_queue` rows (ordered by `received_at`), insert them into `visits`, and mark them processed.
+- The queue table definition lives at `supabase/sql/visit_queue_table.sql`.
+
+## Performance indexes
+- Ensure the `visits` table has `idx_visits_short_path` to accelerate lookups; the SQL to create it if missing is in `supabase/sql/visits_short_path_index.sql`.

--- a/supabase/sql/visit_queue_table.sql
+++ b/supabase/sql/visit_queue_table.sql
@@ -1,0 +1,18 @@
+-- Queue table for deferred visit processing
+CREATE TABLE IF NOT EXISTS visit_queue (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  short_path text NOT NULL,
+  ip_address text,
+  user_agent text,
+  environment text,
+  version_number text,
+  user_id uuid,
+  browser text,
+  os text,
+  received_at timestamptz DEFAULT now() NOT NULL,
+  processed_at timestamptz,
+  processing_status text DEFAULT 'pending'
+);
+
+CREATE INDEX IF NOT EXISTS idx_visit_queue_status_received_at
+  ON visit_queue (processing_status, received_at);

--- a/supabase/sql/visits_short_path_index.sql
+++ b/supabase/sql/visits_short_path_index.sql
@@ -1,0 +1,2 @@
+-- Ensure lookups by short_path are indexed for visit processing
+CREATE INDEX IF NOT EXISTS idx_visits_short_path ON visits (short_path);


### PR DESCRIPTION
## Summary
- upsert user IP mappings to avoid redundant lookups and ensure unique association per address
- enqueue visit logs for asynchronous batch processing via a Supabase-backed queue
- add SQL helpers to ensure visit queue support and a short_path index on visits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c4fe3eda8832a8fd00fbc83e9373b)