### PR TITLE
Normalize Redis URL configuration

### DIFF
--- a/src/app/lib/redis.js
+++ b/src/app/lib/redis.js
@@ -1,6 +1,10 @@
 import { createClient } from 'redis';
 
-const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+function normalizeRedisUrl(url) {
+  return (url || '').trim().replace(/^['"]|['"]$/g, '');
+}
+
+const REDIS_URL = normalizeRedisUrl(process.env.REDIS_URL) || 'redis://localhost:6379';
 const CIRCUIT_BREAKER_THRESHOLD = Number(process.env.REDIS_CIRCUIT_BREAKER_THRESHOLD || 3);
 const CIRCUIT_BREAKER_RESET_MS = Number(process.env.REDIS_CIRCUIT_BREAKER_RESET_MS || 30_000);
 const KEEP_ALIVE_INTERVAL_MS = Number(process.env.REDIS_KEEP_ALIVE_INTERVAL_MS || 30_000);


### PR DESCRIPTION
## Summary
- trim quotes and whitespace from the configured Redis URL before creating clients
- retain default local Redis URL when none is provided

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e1b346874832a8177b6a5ed5d8c96)