### PR TITLE
Fix async params handling and Redis client usage

### DIFF
--- a/src/app/[id]/page.js
+++ b/src/app/[id]/page.js
@@ -2,7 +2,7 @@ import { fetchRedirectUrl, logUserData } from '../utils';
 import { redirect } from 'next/navigation';
 
 export default async function Page(props) {
-  const params = props.params;
+  const params = await props.params;
   const { id } = params;
 
   const urlDataPromise = fetchRedirectUrl(id);

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -12,7 +12,7 @@ export async function fetchRedirectUrl(location) {
     return null;
   }
 
-  const redis = getRedisClient();
+  const redis = await getRedisClient();
   const cacheKey = `redirect:${location}`;
 
   if (redis) {


### PR DESCRIPTION
## Summary
- await dynamic route params before destructuring to satisfy Next.js requirements
- await Redis client creation so cache helpers use actual client instances

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e7cf9507c832a9c5beacc6adf7fcb)